### PR TITLE
Jquery feature detection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The plugin automatically adds `class="placeholder"` to the elements who are curr
 
 * Works in all A-grade browsers, including IE6.
 * The plugin automatically checks if the browser natively supports the HTML5 `placeholder` attribute for `input` and `textarea` elements. If this is the case, the plugin won’t do anything. If `@placeholder` is only supported for `input` elements, the plugin will leave those alone and apply to `textarea`s exclusively. (This is the case for Safari 4, Opera 11.00, and possibly other browsers.)
+* It also exposes whether the browser natively supports `placeholder` attributes through a public `jQuery.support.placeholder` feature detection property.
 
 ## License
 

--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -7,7 +7,8 @@
 
 	var isInputSupported = 'placeholder' in document.createElement('input'),
 	    isTextareaSupported = 'placeholder' in document.createElement('textarea');
-	if (isInputSupported && isTextareaSupported) {
+  $.support.placeholder = isInputSupported && isTextareaSupported;
+	if ($.support.placeholder) {
 		$.fn.placeholder = function() {
 			return this;
 		};


### PR DESCRIPTION
In addition to using the features of your plugin, I also needed to know whether the browser natively supported placeholder attributes.  Seeing that the plugin already has logic to determine this, I modified it to expose the feature detection through the `jQuery.support.placeholder` property.  

This commit includes the change, but I didn't bump the version nor re-generate a new minified version.
