### PR TITLE
Don't setPlaceholder if the element has focus. Fixes #56.

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -45,8 +45,11 @@
 				}
 				if (value == '') {
 					element.value = value;
-					// We can’t use `triggerHandler` here because of dummy text/password inputs :(
-					setPlaceholder.call(element);
+					// Issue #56: Setting the placeholder causes problems if the element continues to have focus.
+					if (!$element.is(':focus')) {
+						// We can’t use `triggerHandler` here because of dummy text/password inputs :(
+						setPlaceholder.call(element);
+					}
 				} else if ($element.hasClass('placeholder')) {
 					clearPlaceholder.call(element, true, value) || (element.value = value);
 				} else {


### PR DESCRIPTION
This fixes a problem in which the placeholder functionality breaks if val('') is called while a field has focus.
