### PR TITLE
Apply placeholder functionality if value matches placeholder, to fix bac...

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -117,9 +117,9 @@
 		var $replacement,
 		    input = this,
 		    $input = $(input),
-		    $origInput = $input,
+		    placeholderText = $input.attr('placeholder'),
 		    id = this.id;
-		if (input.value == '') {
+		if (input.value == '' || input.value == placeholderText) {
 			if (input.type == 'password') {
 				if (!$input.data('placeholder-textinput')) {
 					try {
@@ -145,7 +145,7 @@
 				// Note: `$input[0] != input` now!
 			}
 			$input.addClass('placeholder');
-			$input[0].value = $input.attr('placeholder');
+			$input[0].value = placeholderText;
 		} else {
 			$input.removeClass('placeholder');
 		}


### PR DESCRIPTION
...k button and refresh problems (IE9). Fixes #58.

This patch has the side-effect (depending on your point of view, regression?) of not allowing the exact placeholder text itself to be entered into a field. If the placeholder text is entered, it will be treated as blank. In my opinion, this is desirable behavior, as I believe most web apps would prefer to treat the exact placeholder text as blank (like "use the default"), and it is likely to fix other non-obvious back button / refresh problems.

Also, I'm not thinking of a better way to fix this.

This patch also removes an apparently useless variable declaration of $origInput.
