### PR TITLE
Adding the ability to teardown the placeholder plugin on an element that...

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -19,16 +19,28 @@
 	} else {
 
 		placeholder = prototype.placeholder = function() {
-			var $this = this;
-			$this
-				.filter((isInputSupported ? 'textarea' : ':input') + '[placeholder]')
-				.not('.placeholder')
-				.bind({
-					'focus.placeholder': clearPlaceholder,
-					'blur.placeholder': setPlaceholder
-				})
-				.data('placeholder-enabled', true)
-				.trigger('blur.placeholder');
+			var $this = this,
+        $placeholders = $this.filter((isInputSupported ? 'textarea' : ':input') + '[placeholder]')
+      
+      if (arguments.length > 0 && arguments[0] == 'destroy') {
+        $placeholders
+          .filter( function() { return $(this).data('placeholder-enabled') === true; })
+          .trigger('focus.placeholder')
+          .removeData('placeholder-enabled')
+          .removeData('placeholder-id')
+          .each( function() { var $replacement; if ($replacement = $(this).data('placeholder-textinput')){ $replacement.remove(); }}) 
+          .removeData('placeholder-textinput')
+          .unbind('.placeholder');
+      } else {
+        $placeholders
+          .not('.placeholder')
+          .bind({
+            'focus.placeholder': clearPlaceholder,
+            'blur.placeholder': setPlaceholder
+          })
+          .data('placeholder-enabled', true)
+          .trigger('blur.placeholder');
+      }
 			return $this;
 		};
 


### PR DESCRIPTION
... previously had set it up. The intent is to restore the element to its state before calling the plugin.

This is similar to how jquery ui plugins provide a destroy option. It would look something like:
```js
$("input").placeholder()
...
$("input").placeholder('destroy')
```

