### PR TITLE
Fixed IE9 bug

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -1,8 +1,10 @@
 /*! http://mths.be/placeholder v2.0.7 by @mathias */
 ;(function(window, document, $) {
 
-	var isInputSupported = 'placeholder' in document.createElement('input'),
-	    isTextareaSupported = 'placeholder' in document.createElement('textarea'),
+	var i = document.createElement("input"),
+	    isInputSupported = typeof i.placeholder !== 'undefined',
+	    t = document.createElement("textarea"),
+	    isTextareaSupported = typeof t.placeholder !== 'undefined',
 	    prototype = $.fn,
 	    valHooks = $.valHooks,
 	    hooks,


### PR DESCRIPTION
In a test made with IE9 virtualized with parallels I had errors when identifying if the "placeholder" attribute was supported or not.

The issue was resolved with this little modification
