### PR TITLE
Fixed IE9 error when accessing from an iframe.

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -48,10 +48,14 @@
 				if (value == '') {
 					element.value = value;
 					// Issue #56: Setting the placeholder causes problems if the element continues to have focus.
-					if (element != document.activeElement) {
+					try { 
+						//IE9 has throws "unspecified error" with document.activeElement when inside of an iframe.
+						//JQuery mobile wraps in empty try/catch to "fix" https://github.com/jquery/jquery-mobile/issues/2064
+						if (element != document.activeElement) {
 						// We can't use `triggerHandler` here because of dummy text/password inputs :(
-						setPlaceholder.call(element);
-					}
+							setPlaceholder.call(element);
+						}
+					} catch(e){}
 				} else if ($element.hasClass('placeholder')) {
 					clearPlaceholder.call(element, true, value) || (element.value = value);
 				} else {
@@ -111,7 +115,11 @@
 			} else {
 				input.value = '';
 				$input.removeClass('placeholder');
-				input == document.activeElement && input.select();
+				try { 
+					//IE9 has throws "unspecified error" with document.activeElement when inside of an iframe.
+					//JQuery mobile wraps in empty try/catch to "fix" https://github.com/jquery/jquery-mobile/issues/2064
+					input == document.activeElement && input.select();
+				} catch(e) {}
 			}
 		}
 	}


### PR DESCRIPTION
This pull request includes the changes in https://github.com/mathiasbynens/jquery-placeholder/pull/87

I just included the try/catch block around the other reference to document.activeElement that causes the Unspecified Error in IE9 iframes.
