### PR TITLE
IE bugfix for password field (tested with JQuery 1.4.2 and v.1.8.7)

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -71,7 +71,7 @@
 				// Clear the placeholder values so they don't get submitted
 				var $inputs = $('.placeholder', this).each(clearPlaceholder);
 				setTimeout(function() {
-					$inputs.each(setPlaceholder);
+					$(this).each(setPlaceholder);
 				}, 10);
 			});
 		});


### PR DESCRIPTION
Doesn't work for password field in IE7/8 after form having been ajax-submitted. Works after this fix applied.