### PR TITLE
Removed dependency on deprecated bind method

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -6,7 +6,8 @@
 	    prototype = $.fn,
 	    valHooks = $.valHooks,
 	    hooks,
-	    placeholder;
+	    placeholder,
+	    binder = $.fn.on ? 'on': 'bind';
 
 	if (isInputSupported && isTextareaSupported) {
 
@@ -23,7 +24,7 @@
 			$this
 				.filter((isInputSupported ? 'textarea' : ':input') + '[placeholder]')
 				.not('.placeholder')
-				.bind({
+				[binder]({
 					'focus.placeholder': clearPlaceholder,
 					'blur.placeholder': setPlaceholder
 				})
@@ -136,7 +137,7 @@
 							'placeholder-password': true,
 							'placeholder-id': id
 						})
-						.bind('focus.placeholder', clearPlaceholder);
+						[binder]('focus.placeholder', clearPlaceholder);
 					$input
 						.data({
 							'placeholder-textinput': $replacement,


### PR DESCRIPTION
I've not tested this out (as don't have a browser that doesn't support native placeholders installed) but applied the same fix I used in https://github.com/wheresrhys/jquery.flickbook, and it works ok in that plugin

minified version doesn't include the change
