### PR TITLE
Use a custom event for the trigger instead of blur

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -25,10 +25,11 @@
 				.not('.placeholder')
 				.bind({
 					'focus.placeholder': clearPlaceholder,
-					'blur.placeholder': setPlaceholder
+					'blur.placeholder': setPlaceholder,
+					'phinit.placeholder': setPlaceholder
 				})
 				.data('placeholder-enabled', true)
-				.trigger('blur.placeholder');
+				.trigger('phinit.placeholder');
 			return $this;
 		};
 


### PR DESCRIPTION
triggering the blur event on the elements was triggering other form validation events before the user had started interacting with my form.
I created a new custom init event that trigger can use with out kicking off other unrelated events.