### PR TITLE
Added .prop('placeholder') test

### DIFF
--- a/tests/tests.js
+++ b/tests/tests.js
@@ -49,6 +49,13 @@
 		strictEqual($el.prop('value'), '', '`$el.val("")` should change the `value` property');
 		strictEqual(el.value, placeholder, '`$el.val("")` should change the `value` attribute');
 		ok($el.hasClass('placeholder'), '`$el.val("")` should re-enable `placeholder` class');
+
+		// make sure the placeholder property works as expected.
+		strictEqual($el.prop('placeholder'), placeholder, '$el.prop(`placeholder`) should return the placeholder value');
+		$el.prop('placeholder', 'new placeholder');
+		strictEqual($el.prop('placeholder'), 'new placeholder', '$el.prop(`placeholder`, <string>) should set the placeholder value');
+		strictEqual($el.value, 'new placeholder', '$el.prop(`placeholder`, <string>) should update the displayed placeholder value');
+		$el.prop('placeholder', placeholder);
 	};
 
 	test('emulates placeholder for <input type=text>', function() {


### PR DESCRIPTION
So that you'll get a more clear view of what issue #145 is asking for.

Please run the new tests in a browser that doesn't support placeholder natively.

Note that when I forked your repo, some tests unrelated to mine were failing. The test number 6 "`value` should be the empty string on focus" to be more precise.
