### PR TITLE
Don't trigger a blur to set the placeholder

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -28,7 +28,7 @@
 					'blur.placeholder': setPlaceholder
 				})
 				.data('placeholder-enabled', true)
-				.trigger('blur.placeholder');
+				.each(setPlaceholder);
 			return $this;
 		};
 


### PR DESCRIPTION
This causes problems when blur also does other things, and on IE8/9
where it will defocus a thing that you expect to be focused (e.g. when
you're polyfilling placeholders into newly created content on a page).