### PR TITLE
Fix a bug in IE7 and IE8

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -166,7 +166,7 @@
 				// Note: `$input[0] != input` now!
 			}
 			$input.addClass('placeholder');
-			$input[0].value = $input.attr('placeholder');
+			$input[0].value = $input.attr('placeholder') ?  $input.attr('placeholder') : '';
 		} else {
 			$input.removeClass('placeholder');
 		}


### PR DESCRIPTION
![untitled](https://f.cloud.github.com/assets/1493603/1528274/0f94186c-4c06-11e3-88d2-0e406b4d45e7.png)

When using [selectize](https://github.com/brianreavis/selectize.js) alongside jquery.placeholder, it adds the string 'undefined' when clicking on a selected value to change it. This is caused because the placeholder is set with an [empty option inside select](http://dev.w3.org/html5/spec-preview/the-select-element.html), then [selectize](https://github.com/brianreavis/selectize.js/pull/69) turn this to an `input` element and set the proper `placeholder` attribute. It means an unnecessary placeholder event has been fired on an element which expected to have placeholder. This change fix this issue by checking if the value of`placeholder` attribute is valid before adding it to the `input` element. This good be an idea to implement placeholder support for `select` elements as it is conformed with [w3c](http://dev.w3.org/html5/spec-preview/the-select-element.html).
