### PR TITLE
fixes issues with placeholders getting cleared on IE8/9 on javascript hrefs via the onbeforeunload

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -93,6 +93,15 @@
 					$inputs.each(setPlaceholder);
 				}, 10);
 			});
+
+			// Prevent anchor tags with javascript hrefs from triggering window.onbeforeunload
+			$('a[href^="javascript:"]').hover( function(){
+			    window.onbeforeunload=null;
+			  },
+			  function(){
+			    window.onbeforeunload=$(window).data('beforeunload');
+			  }
+			);
 		});
 
 		// Clear placeholder values upon page reload


### PR DESCRIPTION
credit to @Schlogen. just moving it to the on ready block so it can bind on elements when they are present.