### PR TITLE
Fix the link to the v1.8.7 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ bower install jquery-placeholder
 
 ## Notes
 
-* Requires jQuery 1.6+. For an older version of this plugin that works under jQuery 1.4.2+, see [v1.8.7](https://github.com/mathiasbynens/jquery-placeholder/tree/1.8.7).
+* Requires jQuery 1.6+. For an older version of this plugin that works under jQuery 1.4.2+, see [v1.8.7](https://github.com/mathiasbynens/jquery-placeholder/tree/v1.8.7).
 * Works in all A-grade browsers, including IE6.
 * Automatically checks if the browser natively supports the HTML5 `placeholder` attribute for `input` and `textarea` elements. If this is the case, the plugin won’t do anything. If `@placeholder` is only supported for `input` elements, the plugin will leave those alone and apply to `textarea`s exclusively. (This is the case for Safari 4, Opera 11.00, and possibly other browsers.)
 * Caches the results of its two feature tests in `jQuery.fn.placeholder.input` and `jQuery.fn.placeholder.textarea`. For example, if `@placeholder` is natively supported for `input` elements, `jQuery.fn.placeholder.input` will be `true`. After loading the plugin, you can re-use these properties in your own code.


### PR DESCRIPTION
I saw the hint that I should use the version 1.8.7 in order to get jQuery Placeholder working with jQuery 1.4.2+. I clicked the link and I got a 404 so I fixed that link to. You just forgot the "v" character.
