### PR TITLE
Update jquery.placeholder.js

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -88,7 +88,7 @@
 
 		$(function() {
 			// Look for forms
-			$(document).delegate('form', 'submit.placeholder', function() {
+			$(document).delegate('submit.placeholder','form', function() {
 				// Clear the placeholder values so they don't get submitted
 				var $inputs = $('.placeholder', this).each(clearPlaceholder);
 				setTimeout(function() {


### PR DESCRIPTION
The jquery placeholder plugin takes care that elements that don't support a placeholder are assigned to the 'value' attribute. But on the moment of the submit they must be detached from what is already in the code. Only problem with the existing code was that the selector and event arguments are in the wrong order which caused the code not to execute.
