### PR TITLE
Fix for framed windows in IE8 & IE9

### DIFF
--- a/jquery.placeholder.js
+++ b/jquery.placeholder.js
@@ -178,7 +178,7 @@
 		// Avoid IE9 `document.activeElement` of death
 		// https://github.com/mathiasbynens/jquery-placeholder/pull/99
 		try {
-			return document.activeElement;
+			return document.documentElement.activeElement;
 		} catch (exception) {}
 	}
 


### PR DESCRIPTION
added 'documentElement' to the return statement to avoid errors in IE8
and IE9
