### PR TITLE
Only include bower.json and jquery.placeholder.js in our bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,10 @@
 {
 	"name": "jquery-placeholder",
 	"version": "2.0.8",
-	"main": ["jquery.placeholder.js"]
+	"main": ["jquery.placeholder.js"],
+	"ignore": [
+		"*",
+		"!/bower.json",
+		"!/jquery.placeholder.js"
+	]
 }


### PR DESCRIPTION
Users of this package don't need our tests, README, etc.
